### PR TITLE
Improve Slot Behavior

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,6 @@ jobs:
     - name: Deps
       run: sudo apt-get install clang-6.0 yasm autoconf2.13
     - name: Build
-      run: cargo build --verbose
+      run: SHELL=/bin/bash cargo build --verbose
     - name: Run tests
       run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Deps
-      run: sudo apt-get install clang-6.0 yasm autoconf
+      run: sudo apt-get install clang-6.0 yasm autoconf2.13
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Ideas.md
+++ b/Ideas.md
@@ -1,0 +1,10 @@
+
+<!-- in the child... -->
+<layout src="./server/src/html/base.html">
+  <script slot="javascript" src="https://richinfante.com/example.js"></script>
+</layout>
+
+<!-- in the parent -->
+<slot name="javascript-head" multiple></slot>
+<slot name="javascript" multiple></slot>
+<slot name="css" multiple></slot>

--- a/examples/2018-02-12-visualizing-algorithms.md
+++ b/examples/2018-02-12-visualizing-algorithms.md
@@ -12,6 +12,12 @@ description_in_listing: true
 notruncate: false
 ---
 
+<div slot="javascript">
+<!-- BEGIN SLOT CONTENTS -->
+<div src="https://richinfante.com/script.js"></div>
+<!-- END SLOT CONTENTS -->
+</div>
+
 ## Introduction
 
 I recently  <a href="https://twitter.com/richinfante/status/959984976090619904">shared this on twitter</a>, and wanted to share a bit more about how I did it:

--- a/examples/2018-02-12-visualizing-algorithms.md
+++ b/examples/2018-02-12-visualizing-algorithms.md
@@ -12,11 +12,8 @@ description_in_listing: true
 notruncate: false
 ---
 
-<div slot="javascript">
-<!-- BEGIN SLOT CONTENTS -->
-<div src="https://richinfante.com/script.js"></div>
-<!-- END SLOT CONTENTS -->
-</div>
+<script slot="javascript" src="https://richinfante.com/script.js"></script>
+<link slot="stylesheet" rel="stylesheet" href="https://richinfante.com/styles.css"/>
 
 ## Introduction
 

--- a/examples/for.html
+++ b/examples/for.html
@@ -13,6 +13,8 @@
   ]
   </script>
   
+  
+
   <div x-for="item in items" x-index="$i">
     {{$i}} {{item}}
   </div>

--- a/examples/layout.html
+++ b/examples/layout.html
@@ -42,6 +42,7 @@
   if (DEBUG) {
     console.warn("debug mode is enabled!");
   }
+  console.log(...Object.keys(page))
   </script>
 </head>
 <body>
@@ -56,6 +57,7 @@
   </main>
   <footer>
     <slot src="./examples/footer.html"></slot>
+    <slot name="footer"></slot>
     <pre style="white-space: break-spaces;">{{fs.readFileSync('./README.md')}}</pre>
   </footer>
 </body>

--- a/examples/layout.html
+++ b/examples/layout.html
@@ -37,6 +37,7 @@
   <!-- End Icons-->
 
   <script src="./examples/foo.js" static></script>
+
   <script static>
   var DEBUG = true;
   if (DEBUG) {
@@ -44,6 +45,8 @@
   }
   console.log(...Object.keys(page))
   </script>
+
+  <meta name="twitter:description2" :content="child.description">
 </head>
 <body>
   <header>
@@ -58,6 +61,9 @@
   <footer>
     <slot src="./examples/footer.html"></slot>
     <slot name="footer"></slot>
+    <!-- BEFORE SLOT -->
+    <slot name="javascript"></slot>
+    <!-- AFTET SLOT -->
     <pre style="white-space: break-spaces;">{{fs.readFileSync('./README.md')}}</pre>
   </footer>
 </body>

--- a/examples/layout.html
+++ b/examples/layout.html
@@ -32,12 +32,12 @@
   <!-- End Twitter Metadata -->
 
   <!-- Begin Icons -->
+  <!-- slot: stylesheet -->
   <link rel="icon" href="/img/profile_image.jpg" type="image/png">
   <link rel="shortcut icon" href="/img/profile_image.jpg" type="image/png">
   <!-- End Icons-->
 
   <script src="./examples/foo.js" static></script>
-
   <script static>
   var DEBUG = true;
   if (DEBUG) {
@@ -45,8 +45,6 @@
   }
   console.log(...Object.keys(page))
   </script>
-
-  <meta name="twitter:description2" :content="child.description">
 </head>
 <body>
   <header>
@@ -60,11 +58,11 @@
   </main>
   <footer>
     <slot src="./examples/footer.html"></slot>
+    <!-- include: ./examples/footer.html -->
+
     <slot name="footer"></slot>
-    <!-- BEFORE SLOT -->
     <slot name="javascript"></slot>
-    <!-- AFTET SLOT -->
-    <pre style="white-space: break-spaces;">{{fs.readFileSync('./README.md')}}</pre>
+    <!-- <pre style="white-space: break-spaces;">{{fs.readFileSync('./README.md')}}</pre>-->
   </footer>
 </body>
 </html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,7 +589,7 @@ unsafe fn render_children(
             } else if node_name == "slot" && get_attribute(node, "name") .is_some() {
                 let slot_name = get_attribute(node, "name").unwrap();
 
-                if slot_name == "contents"  {
+                if slot_name == "content"  {
                     if let Some(contents) = slot_contents.clone().borrow() {
                         trace!("swapping slot contents into dom tree.");
                         let doc: &Node = contents.document.borrow();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -514,8 +514,13 @@ unsafe fn render_children(
             let mut final_attrs: Vec<html5ever::interface::Attribute> = vec![];
             let mut loop_name = get_attribute(node, "x-as").unwrap_or("item".to_string());
             let mut index_name = get_attribute(node, "x-index").unwrap_or("i".to_string());
-
-            if node_name == "slot" && get_attribute(node, "name") == Some("content".into()) {
+            if let Some(val) = get_attribute(node, "slot") {
+                info!("found slot contents for {}", val);
+                return  CondGenFlags {
+                    remove: true,
+                    replace: None
+                }
+            } else if node_name == "slot" && get_attribute(node, "name") == Some("content".into()) {
                 if let Some(contents) = slot_contents.clone().borrow() {
                     trace!("swapping slot contents into dom tree.");
                     let doc: &Node = contents.document.borrow();


### PR DESCRIPTION
Adding named slots behavior, with the following syntaxes:

```
<!-- slot: javascript -->
<slot name="javascript"></slot>
```

The comment-based syntax is a temporary hack until I figure out why the parser moves unknown elements out of the &lt;head&gt;.

Introduced a new struct called `RenderContext` which stores:
- nodes that are declared to be in a slot, so when running layout pass we can insert them.
- child render context(s) used for layout
- contents of the entire sub-layout.